### PR TITLE
Replaced newlib ftp by https

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -27,7 +27,7 @@ if [ ! -f glibc-$PKG_GLIBC.tar.gz ]; then
 fi
 # newlib
 if [ ! -f newlib-${PKG_NEWLIB}.tar.gz ]; then
-  wget "ftp://sourceware.org/pub/newlib/newlib-${PKG_NEWLIB}.tar.gz"
+  wget "https://www.sourceware.org/pub/newlib/newlib-${PKG_NEWLIB}.tar.gz"
   tar -xzf newlib-${PKG_NEWLIB}.tar.gz
 fi
 # cppcheck

--- a/toolchain-build.sh
+++ b/toolchain-build.sh
@@ -85,4 +85,4 @@ if [[ -z "$TRAVIS" && $GDB_VERSION != $PKG_GDB ]]; then
 fi
 
 # Cleanup everything unnecessary
-rm -rf "$TARGET_COMPILE"
+rm -rf "$TARGET_COMPILE/build"


### PR DESCRIPTION
In order to be used on travis, the fetch of newlib has been changed to https. Furthermore the sources won't be cleaned up too.